### PR TITLE
Fix comment

### DIFF
--- a/encoder_zig/src/encoder.zig
+++ b/encoder_zig/src/encoder.zig
@@ -93,7 +93,7 @@ fn Update(params: ?*c.ExtensionParams) callconv(.C) c_int {
     return c.EXTENSION_RESULT_OK;
 }
 
-// The "ExtensionZIG" in ext.manifest, makes the engine call this function upon starting the engine
+// The `name: "ExtensionZig"` in ext.manifest, makes the engine call this function upon starting the engine
 export fn ExtensionZig() callconv(.C) void {
     c.ExtensionRegister(@ptrCast(&g_ExtensionDesc), g_ExtensionDesc.len, "ExtensionZig",
                         null, null, Initialize, Finalize, Update, null);


### PR DESCRIPTION
I went to https://github.com/defold/example-languages/blob/ba808e413543db1165b675534c6b5f224eca521b/encoder_zig/ext.manifest and found out that the `ExtensionZIG` in the comment is supposed to be `ExtensionZig`.