### PR TITLE
C# - Use `Span<char>` to stack allocate

### DIFF
--- a/encoder_cs/src/encoder.cs
+++ b/encoder_cs/src/encoder.cs
@@ -27,7 +27,7 @@ public unsafe partial class CS
     private static int Rot13(Lua.State* L)
     {
         String s = LuaL.checkstring(L, 1);
-        var newStringChars = new char[s.Length];
+        Span<char> newStringChars = stackalloc char[s.Length];
         for (int i = 0; i < s.Length; i++)
             newStringChars[i] = shift(s[i]);
 


### PR DESCRIPTION
I'm not sure how you're running the benchmarks so I couldn't test this, but this might improve the C# performance a bit more by replacing 1 heap allocation with a stackalloc 